### PR TITLE
fix: handle parser diagnostics

### DIFF
--- a/src/core/analyze.test.ts
+++ b/src/core/analyze.test.ts
@@ -221,7 +221,7 @@ const mixed = import.meta.glob("literal", someVar, 123);
     });
 
     it("should handle non-MemberExpression callees", () => {
-      const code = "const result = someFunction('./test');";
+      const code = "const result = resolve('./test');";
       const ImportMetaBindings: ImportMetaBindings = {
         functions: {
           resolve: (path: bigint | boolean | number | string | RegExp | null) =>
@@ -231,14 +231,21 @@ const mixed = import.meta.glob("literal", someVar, 123);
       };
 
       const result = analyzeTypeScript(code, ImportMetaBindings);
+      expect(result.replacements).toHaveLength(0);
+    });
 
-      expect(result).toMatchInlineSnapshot(`
-        {
-          "errors": [],
-          "parserDiagnostics": [],
-          "replacements": [],
-        }
-      `);
+    it("should skip traversal on syntax error if surfaced any parser errors", () => {
+      const code = "const x = ; const y = import.meta.foo;";
+      const result = analyzeTypeScript(code, {
+        functions: {},
+        values: {
+          foo: true,
+        },
+      });
+      expect(result.parserDiagnostics.some((d) => d.severity === "error")).toBe(
+        true,
+      );
+      expect(result.replacements).toHaveLength(0);
     });
   });
 });

--- a/src/core/analyze.test.ts
+++ b/src/core/analyze.test.ts
@@ -235,6 +235,7 @@ const mixed = import.meta.glob("literal", someVar, 123);
       expect(result).toMatchInlineSnapshot(`
         {
           "errors": [],
+          "parserDiagnostics": [],
           "replacements": [],
         }
       `);

--- a/src/core/analyze.test.ts
+++ b/src/core/analyze.test.ts
@@ -246,6 +246,7 @@ const mixed = import.meta.glob("literal", someVar, 123);
         true,
       );
       expect(result.replacements).toHaveLength(0);
+      expect(result.errors).toHaveLength(0);
     });
   });
 });

--- a/src/core/languages/astro.ts
+++ b/src/core/languages/astro.ts
@@ -7,7 +7,7 @@ import type {
 import { DiagnosticSeverity } from "@astrojs/compiler/types";
 import { walk } from "zimmerframe";
 
-import type { TransformerContext } from "../context";
+import type { Reporter } from "../reporter";
 import type { ImportMetaBindings, TextReplacement } from "../types";
 import type { LanguageProcessor } from "./types";
 
@@ -91,22 +91,22 @@ export async function createAstroProcessor(): Promise<LanguageProcessor> {
           },
 
           element: (node, c) => {
-            allReplacements.push(...handleTagNode(unCtx, code, node, bindings));
+            allReplacements.push(...handleTagNode(reporter, node, bindings));
             c.next();
           },
 
           fragment: (node, c) => {
-            allReplacements.push(...handleTagNode(unCtx, code, node, bindings));
+            allReplacements.push(...handleTagNode(reporter, node, bindings));
             c.next();
           },
 
           component: (node, c) => {
-            allReplacements.push(...handleTagNode(unCtx, code, node, bindings));
+            allReplacements.push(...handleTagNode(reporter, node, bindings));
             c.next();
           },
 
           "custom-element": (node, c) => {
-            allReplacements.push(...handleTagNode(unCtx, code, node, bindings));
+            allReplacements.push(...handleTagNode(reporter, node, bindings));
             c.next();
           },
 
@@ -154,27 +154,24 @@ export async function createAstroProcessor(): Promise<LanguageProcessor> {
           },
         },
       );
+      if (allReplacements.length === 0) return null;
 
       const transformed = unCtx.helpers.applyReplacements(
         code,
         allReplacements,
       );
 
-      return {
-        code: transformed,
-      };
+      return { code: transformed };
     },
   };
 }
 
 function handleTagNode(
-  ctx: TransformerContext,
-  code: string,
+  reporter: Reporter,
   node: TagLikeNode,
   bindings: ImportMetaBindings,
 ): TextReplacement[] {
   const allReplacements: TextReplacement[] = [];
-  const reporter = createReporter(ctx);
 
   for (const attr of node.attributes) {
     if (

--- a/src/core/languages/astro.ts
+++ b/src/core/languages/astro.ts
@@ -53,13 +53,14 @@ export async function createAstroProcessor(): Promise<LanguageProcessor> {
         for (const err of severeDiagnostics.error) {
           reporter.error({ message: err.text, meta: err.location });
         }
+        // abort processing on parse error
         return null;
       }
       if (severeDiagnostics.warning.length > 0) {
         for (const warn of severeDiagnostics.warning) {
           reporter.warn({ message: warn.text, meta: warn.location });
         }
-        return null;
+        // continue processing even if there are warnings
       }
 
       const allReplacements: TextReplacement[] = [];
@@ -183,10 +184,10 @@ function handleTagNode(
 
     if (attr.kind === "shorthand" || attr.kind === "spread") {
       // TODO: contribution is welcome
-      reporter.warn(
-        `<${node.name}>: Skipping unsupported attribute syntax: ${attr.kind} for "${attr.name}"`,
-      );
-      continue;
+      reporter.warn({
+        message: `<${node.name}>: Skipping unsupported attribute syntax: ${attr.kind} for "${attr.name}"`,
+        meta: attr.position,
+      });
     }
 
     if (includesImportMeta(attr.value)) {

--- a/src/core/languages/ecmascript.ts
+++ b/src/core/languages/ecmascript.ts
@@ -13,6 +13,7 @@ export function createECMAScriptProcessor(): LanguageProcessor {
       const result = analyzeTypeScript(code, bindings);
       const { hasParserError } = reporter.reportAnalysis(result);
       if (hasParserError) return null;
+      if (result.replacements.length === 0) return null;
 
       const transformed = c.helpers.applyReplacements(
         code,

--- a/src/core/languages/ecmascript.ts
+++ b/src/core/languages/ecmascript.ts
@@ -1,6 +1,7 @@
 import type { LanguageProcessor } from "./types";
 
 import { analyzeTypeScript } from "../analyze";
+import { createReporter } from "../reporter";
 
 /**
  * @package
@@ -8,16 +9,10 @@ import { analyzeTypeScript } from "../analyze";
 export function createECMAScriptProcessor(): LanguageProcessor {
   return {
     transform(c, code, bindings) {
+      const reporter = createReporter(c);
       const result = analyzeTypeScript(code, bindings);
-      if (result.errors.length > 0) {
-        for (const err of result.errors) {
-          c.logger.error({
-            id: c.id,
-            message: err.message,
-            meta: err.meta,
-          });
-        }
-      }
+      const { hasParserError } = reporter.reportAnalysis(result);
+      if (hasParserError) return null;
 
       const transformed = c.helpers.applyReplacements(
         code,

--- a/src/core/languages/vue.ts
+++ b/src/core/languages/vue.ts
@@ -39,8 +39,9 @@ export async function createVueProcessor(): Promise<LanguageProcessor> {
       });
       if (errors.length > 0) {
         for (const err of errors) {
-          reporter.error({ message: err.message, meta: err });
+          reporter.error(err);
         }
+        // abort processing on parse error
         return null;
       }
 

--- a/src/core/languages/vue.ts
+++ b/src/core/languages/vue.ts
@@ -62,6 +62,7 @@ export async function createVueProcessor(): Promise<LanguageProcessor> {
         }));
         allReplacements.push(...adjustedReplacements);
       }
+      if (allReplacements.length === 0) return null;
 
       return {
         code: c.helpers.applyReplacements(code, allReplacements),

--- a/src/core/reporter.ts
+++ b/src/core/reporter.ts
@@ -1,0 +1,70 @@
+import type { UnpluginContext } from "unplugin";
+
+import type { AnalysisResult, ParserDiagnostic } from "./analyze";
+import type { TransformerContext } from "./context";
+
+type LogInput = string | Error | { message: string; meta?: unknown };
+
+export interface Reporter {
+  error(input: LogInput): void;
+  /**
+   * Report analysis errors and parser diagnostics.
+   * Returns whether parser reported a fatal error.
+   */
+  reportAnalysis(result: AnalysisResult): { hasParserError: boolean };
+  warn(input: LogInput): void;
+}
+
+export function createReporter(ctx: TransformerContext): Reporter {
+  const emit = (kind: "error" | "warn", input: LogInput) => {
+    const fn: UnpluginContext["error"] | UnpluginContext["warn"] =
+      kind === "error" ? ctx.logger.error : ctx.logger.warn;
+
+    if (typeof input === "string") {
+      // normalize to Rollup-like object with id
+      fn({ id: ctx.id, message: input });
+      return;
+    }
+    if (input instanceof Error) {
+      fn({ id: ctx.id, message: input.message, meta: input });
+      return;
+    }
+
+    fn({ id: ctx.id, message: input.message, meta: input.meta });
+  };
+
+  const reportParser = (diags: ParserDiagnostic[]) => {
+    let hasError = false;
+    for (const d of diags) {
+      if (d.severity === "error") hasError = true;
+      emit(d.severity === "error" ? "error" : "warn", {
+        message: d.message,
+        meta: {
+          end: d.end,
+          start: d.start,
+          ...d.meta,
+        },
+      });
+    }
+    return hasError;
+  };
+
+  return {
+    error(input) {
+      emit("error", input);
+    },
+    reportAnalysis(result) {
+      // Analyzer-level errors
+      for (const err of result.errors) {
+        emit("error", { message: err.message, meta: err.meta });
+      }
+
+      // Parser diagnostics
+      const hasParserError = reportParser(result.parserDiagnostics);
+      return { hasParserError };
+    },
+    warn(input) {
+      emit("warn", input);
+    },
+  };
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parser diagnostics now surface with severity (error/warning/advice), positions, and richer metadata; analysis results include parserDiagnostics and short-circuit transforms on parser errors.

* **Reporting**
  * Unified reporter emits consistent error/warn messages across transforms and surfaces parser diagnostics with locations.

* **Languages**
  * Transform paths (Astro, Vue, Ecmascript) now respect parser diagnostics and early-exit when errors or no replacements are produced.

* **Tests**
  * Tests assert parser diagnostics are reported and that no replacements occur on parse errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->